### PR TITLE
Fix build script for google closure and CommonJS

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -126,7 +126,7 @@ function jsMin() {
 }
 
 function jsClosure(done) {
-  env.NODE_ENV = undefined;
+  delete env.NODE_ENV;
   env.min = false;
   var moduleDeclaration = 'goog.module(\'' + googModuleName + '\');';
 
@@ -141,7 +141,7 @@ function jsClosure(done) {
 }
 
 function jsCommonJS() {
-  env.NODE_ENV = undefined;
+  delete env.NODE_ENV;
   env.min = false;
 
   return bundle('cjs')


### PR DESCRIPTION
When assigning a value to `process.env` it'll be implicitly converted to
string and therefore inline environment variables will always be
transformed even if `env.NODE_ENV` should be `undefined`.
The documentation suggests to use `delete`.
@see https://github.com/nodejs/node/commit/396e4b9199